### PR TITLE
Fix bug with wallet connection names and add label to generated JWT.

### DIFF
--- a/enclave/user.go
+++ b/enclave/user.go
@@ -36,7 +36,7 @@ type User struct {
 }
 
 func (u User) JWT() string {
-	return jwt.BuildJWT(u.DID)
+	return jwt.BuildJWTWithLabel(u.DID, u.DisplayName)
 }
 
 func (u User) Key() []byte {


### PR DESCRIPTION
Apparently the label was accidentally left out from JWT when fixing the token regeneration logic.