### PR TITLE
No need to use github token for dependecies.

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,8 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: use token
-        run: git config --global url."https://"${{ secrets.https_prefix }}"github.com/".insteadOf "https://github.com/"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,9 @@ on:
 jobs:
   e2e:
     runs-on: ubuntu-latest
-    env:
-      HTTPS_PREFIX: ${{ secrets.https_prefix }}
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: use token
-        run: git config --global url."https://"${{ secrets.https_prefix }}"github.com/".insteadOf "git@github.com:"
       - name: test
         run: echo "implement e2e tests"
   merge:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,6 @@ jobs:
           go-version: 1.16.x
       - name: checkout
         uses: actions/checkout@v2
-      - name: use token
-        run: git config --global url."https://"${{ secrets.https_prefix }}"github.com/".insteadOf "https://github.com/"
       - name: test
         run: go test ./...
       - name: scan

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,5 @@
 FROM golang:1.16-alpine3.13
 
-ARG HTTPS_PREFIX
-
-ENV GOPRIVATE "github.com/findy-network"
-
-RUN apk update && \
-    apk add git && \
-    git config --global url."https://"${HTTPS_PREFIX}"github.com/".insteadOf "https://github.com/"
-
 WORKDIR /work
 
 COPY go.* ./

--- a/Makefile
+++ b/Makefile
@@ -55,11 +55,7 @@ dclean:
 	-docker rmi findy-agent-auth
 
 dbuild:
-	@[ "${HTTPS_PREFIX}" ] || ( echo "ERROR: HTTPS_PREFIX <{githubUser}:{githubToken}@> is not set"; exit 1 )
-	docker build \
-		--build-arg HTTPS_PREFIX=$(HTTPS_PREFIX) \
-		-t findy-agent-auth \
-		.
+	docker build -t findy-agent-auth .
 
 drun:
 	docker run -it --rm -p 8888:8888 findy-agent-auth


### PR DESCRIPTION
Only public dependencies so remove use of GitHub token for go build process.