### PR TITLE
added support for `-local-tls` to docker & bug fix & new helper scripts for env testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ ENV FAA_JWT_VERIFICATION_KEY "mySuperSecretKeyLol"
 ENV FAA_SEC_KEY "15308490f1e4026284594dd08d31291bc8ef2aeac730d0daf6ff87bb92d4336c"
 ENV FAA_LOG_LEVEL "3"
 ENV FAA_ENABLE_CORS "false"
+ENV FAA_LOCAL_TLS "false"
 
 RUN echo '[[ ! -z "$STARTUP_FILE_STORAGE_S3" ]] && /s3-copy $STARTUP_FILE_STORAGE_S3 grpc /' > /start.sh && \
     echo '/findy-agent-auth \
@@ -40,6 +41,7 @@ RUN echo '[[ ! -z "$STARTUP_FILE_STORAGE_S3" ]] && /s3-copy $STARTUP_FILE_STORAG
     --cert-path /grpc \
     --logging "-logtostderr=true -v=$FAA_LOG_LEVEL" \
     --cors $FAA_ENABLE_CORS \
+    --local-tls $FAA_LOCAL_TLS \
     --jwt-secret $FAA_JWT_VERIFICATION_KEY' >> /start.sh && chmod a+x /start.sh
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ RUN echo '[[ ! -z "$STARTUP_FILE_STORAGE_S3" ]] && /s3-copy $STARTUP_FILE_STORAG
     --sec-key $FAA_SEC_KEY \
     --cert-path /grpc \
     --logging "-logtostderr=true -v=$FAA_LOG_LEVEL" \
-    --cors $FAA_ENABLE_CORS \
-    --local-tls $FAA_LOCAL_TLS \
+    --cors=$FAA_ENABLE_CORS \
+    --local-tls=$FAA_LOCAL_TLS \
     --jwt-secret $FAA_JWT_VERIFICATION_KEY' >> /start.sh && chmod a+x /start.sh
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 COMM_BRANCH=$(shell ./scripts/branch.sh ../findy-common-go/)
 
+acli:
+	go build -o $(GOPATH)/bin/acli
+
 scan:
 	@./scripts/scan.sh $(ARGS)
 

--- a/main.go
+++ b/main.go
@@ -139,6 +139,7 @@ func main() {
 		glog.Infoln("starting server at", serverAddress)
 	}
 	if isHTTPS {
+		certPath = filepath.Join(certPath, "server")
 		certFile := filepath.Join(certPath, "server.crt")
 		keyFile := filepath.Join(certPath, "server.key")
 		glog.V(3).Infoln("starting TLS server with:\n", certFile, "\n", keyFile)

--- a/scripts/acli-run.sh
+++ b/scripts/acli-run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+acli \
+	$@ \
+	-logging "-logtostderr -v=3" \
+	-origin https://localhost:8090 \
+	-cert-path $GOPATH/src/github.com/findy-network/findy-common-go/cert \
+	-port 8090

--- a/scripts/dev-run.sh
+++ b/scripts/dev-run.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 go run .. \
+	$@ \
 	-logging "-logtostderr -v=3" \
 	-origin http://localhost:8090 \
 	-cert-path $GOPATH/src/github.com/findy-network/findy-common-go/cert \


### PR DESCRIPTION
- added support `-local-tls` flag to `Dockerfile` for cases when https and separated origin is needed
- fixing standard flag package strange parsing issue that caused a bug in `Dockerfile` i.e. boolean envs not transferred
- new build rule for `Makefile` for acli to help dev and testing
- canonized cert file location parsing for https server start