### PR TITLE
Remove user from db on failed register.

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: 45%
+        target: 50%
         threshold: 3%
     patch:
       default:

--- a/enclave/enclave.go
+++ b/enclave/enclave.go
@@ -108,25 +108,17 @@ func GetUser(name string) (u *user.User, exist bool, err error) {
 	return user.NewUserFromData(value.Data), already, err
 }
 
-// GetUserMust returns user by name if exists in enclave
+// GetExistingUser returns user by name if exists in enclave
 func GetExistingUser(name string) (u *user.User, err error) {
 	defer err2.Handle(&err)
 
-	value := &db.Data{
-		Write: decrypt,
-	}
-	already := try.To1(db.GetKeyValueFromBucket(buckets[userByte],
-		&db.Data{
-			Data: []byte(name),
-			Read: hash,
-		},
-		value,
-	))
+	u, already := try.To2(GetUser(name))
+
 	if !already {
 		return nil, fmt.Errorf("user (%s) not exist", name)
 	}
 
-	return user.NewUserFromData(value.Data), err
+	return u, err
 }
 
 func RemoveUser(name string) (err error) {

--- a/enclave/enclave.go
+++ b/enclave/enclave.go
@@ -129,6 +129,16 @@ func GetExistingUser(name string) (u *user.User, err error) {
 	return user.NewUserFromData(value.Data), err
 }
 
+func RemoveUser(name string) (err error) {
+	defer err2.Handle(&err)
+
+	_ = try.To1(GetExistingUser(name))
+	return db.RmKeyValueFromBucket(buckets[userByte], &db.Data{
+		Data: []byte(name),
+		Read: hash,
+	})
+}
+
 // all of the following has same signature. They also panic on error
 
 // hash makes the cryptographic hash of the map key value. This prevents us to

--- a/enclave/enclave_test.go
+++ b/enclave/enclave_test.go
@@ -68,3 +68,24 @@ func TestGetExistingUser(t *testing.T) {
 	_, err = GetExistingUser(emailNotCreated)
 	assert.Error(err)
 }
+
+func TestRemoveUser(t *testing.T) {
+	assert.PushTester(t)
+	defer assert.PopTester()
+
+	const userToRemove = "remove@example.com"
+
+	u := user.NewUser(userToRemove, userToRemove, "")
+	err := PutUser(u)
+	assert.NoError(err)
+	assert.NotNil(u)
+
+	err = RemoveUser(userToRemove)
+	assert.NoError(err)
+
+	_, err = GetExistingUser(userToRemove)
+	assert.Error(err)
+
+	err = RemoveUser(emailNotCreated)
+	assert.Error(err)
+}

--- a/main.go
+++ b/main.go
@@ -236,6 +236,10 @@ func FinishRegistration(w http.ResponseWriter, r *http.Request) {
 
 	defer err2.Handle(&err, func() {
 		glog.Errorln("error:", err)
+
+		// try to remove added user as registration failed
+		_ = enclave.RemoveUser(username)
+
 		jsonResponse(w, err.Error(), http.StatusInternalServerError)
 	})
 


### PR DESCRIPTION
It seems when the registration fails for a reason or another, we still add the user to the db, and it is impossible to try again with the same username.