### PR TITLE
err2 migration v0.9.41

### DIFF
--- a/acator/acator.go
+++ b/acator/acator.go
@@ -33,9 +33,9 @@ func Login(jsonStream io.Reader) (outStream io.Reader, err error) {
 
 	go func() {
 		defer pw.Close()
-		defer err2.Catch(func(err error) {
+		defer err2.Catch(err2.Err(func(err error) {
 			glog.Error(err)
-		})
+		}))
 		ca := tryReadAssertion(jsonStream)
 		car := tryBuildAssertionResponse(ca)
 		try.To(json.NewEncoder(pw).Encode(car))
@@ -112,9 +112,9 @@ func RegisterAsync(jsonStream io.Reader) (outStream io.Reader, err error) {
 
 	go func() {
 		defer pw.Close()
-		defer err2.Catch(func(err error) {
+		defer err2.Catch(err2.Err(func(err error) {
 			glog.Error(err)
-		})
+		}))
 		cred := tryReadCreation(jsonStream)
 		ccr := tryBuildCreationResponse(cred)
 		try.To(json.NewEncoder(pw).Encode(ccr))

--- a/acator/cmd/main.go
+++ b/acator/cmd/main.go
@@ -16,9 +16,9 @@ import (
 func main() {
 	// defer err2.Catch() // todo: err2 v.0.9.0+ this is enouh!!
 
-	defer err2.Catch(func(err error) {
+	defer err2.Catch(err2.Err(func(err error) {
 		fmt.Fprintln(os.Stderr, "error:", err.Error())
-	})
+	}))
 
 	try.To(startServerCmd.Parse(os.Args[1:]))
 	utils.ParseLoggingArgs(loggingFlags)

--- a/acator/enclave/enclave.go
+++ b/acator/enclave/enclave.go
@@ -94,10 +94,10 @@ func (e Enclave) NewKeyHandle() (_ KeyHandle, err error) {
 // IsKeyHandle tells if given byte slice really is key handle from the current
 // Enclave.
 func (e Enclave) IsKeyHandle(credID []byte) (ok bool, kh KeyHandle) {
-	defer err2.Catch(func(err error) {
+	defer err2.Catch(err2.Err(func(err error) {
 		glog.Errorln("is key handle:", err)
 		ok, kh = false, nil
-	})
+	}))
 	pk, err := x509.ParseECPrivateKey(e.Cipher.TryDecrypt(credID))
 	ok = err == nil
 	return ok, newFromPrivateKey(e, pk)

--- a/acator/grpcenclave/client/main.go
+++ b/acator/grpcenclave/client/main.go
@@ -46,9 +46,9 @@ var (
 func main() {
 	err2.SetPanicTracer(os.Stderr)
 	assert.SetDefault(assert.Production)
-	defer err2.Catch(func(err error) {
+	defer err2.Catch(err2.Err(func(err error) {
 		glog.Error(err)
-	})
+	}))
 	flag.Parse()
 
 	// we want this for glog, this is just a tester, not a real world service
@@ -216,7 +216,7 @@ func tryProcess(
 	var (
 		smsg *pb.SecretMsg
 	)
-	defer err2.Catch(func(err error) {
+	defer err2.Catch(err2.Err(func(err error) {
 		smsg = &pb.SecretMsg{
 			CmdID: status.CmdID,
 			Type:  pb.SecretMsg_ERROR,
@@ -227,7 +227,7 @@ func tryProcess(
 			},
 		}
 		_, _ = rpcclient.DoEnterSecret(conn, smsg)
-	})
+	}))
 
 	id := status.GetHandle().ID
 	datas := make([][]byte, 0, 2)

--- a/acator/grpcenclave/grpcenclave.go
+++ b/acator/grpcenclave/grpcenclave.go
@@ -56,10 +56,10 @@ func (e *Enclave) NewKeyHandle() (kh se.KeyHandle, err error) {
 // IsKeyHandle tells if given byte slice really is key handle from the current
 // enclave.
 func (e *Enclave) IsKeyHandle(credID []byte) (ok bool, kh se.KeyHandle) {
-	defer err2.Catch(func(err error) {
+	defer err2.Catch(err2.Err(func(err error) {
 		glog.Errorf("error: is key handle: %v", err)
 		ok, kh = false, nil
-	})
+	}))
 
 	glog.V(3).Infoln("send question IsKeyHandle")
 	e.OutChan <- &pb.CmdStatus{
@@ -168,10 +168,10 @@ func (h *keyHandle) Sign(d []byte) (s []byte, err error) {
 
 // Verify verifies the given data and signature.
 func (h *keyHandle) Verify(data, sig []byte) (ok bool) {
-	defer err2.Catch(func(err error) {
+	defer err2.Catch(err2.Err(func(err error) {
 		glog.Errorf("error: verify: %v", err)
 		ok = false
-	})
+	}))
 
 	h.OutChan <- &pb.CmdStatus{
 		CmdID:   h.CmdID,

--- a/acator/grpcenclave/rpcclient/client.go
+++ b/acator/grpcenclave/rpcclient/client.go
@@ -42,10 +42,10 @@ func DoEnter(
 	stream := try.To1(c.Enter(ctx, cmd))
 	glog.V(3).Infoln("successful start of:", cmd.GetType())
 	go func() {
-		defer err2.Catch(func(err error) {
+		defer err2.Catch(err2.Err(func(err error) {
 			glog.V(3).Infoln("err when reading response", err)
 			close(statusCh)
-		})
+		}))
 		for {
 			status, err := stream.Recv()
 			if try.IsEOF(err) {

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ var (
 	enclaveKey     = "15308490f1e4026284594dd08d31291bc8ef2aeac730d0daf6ff87bb92d4336c"
 	backupInterval = 24 // hours
 	findyAdmin     = "findy-root"
-	certPath       = "./cert"
+	certPath       = ""
 	allowCors      = false
 	isHTTPS        = false
 	testUI         = false

--- a/main.go
+++ b/main.go
@@ -178,15 +178,16 @@ func main() {
 }
 
 func BeginRegistration(w http.ResponseWriter, r *http.Request) {
-	defer err2.Catch(func(err error) {
+	defer err2.Catch(err2.Err(func(err error) {
 		glog.Warningln("begin registration error:", err)
-	})
+	}))
 
 	var err error
 	// get username/friendly name
 
-	defer err2.Handle(&err, func() {
+	defer err2.Handle(&err, func(err error) error {
 		jsonResponse(w, err.Error(), http.StatusBadRequest)
+		return err
 	})
 
 	// get username
@@ -216,9 +217,10 @@ func BeginRegistration(w http.ResponseWriter, r *http.Request) {
 		glog.V(1).Infoln("credexcl:", len(credCreationOpts.CredentialExcludeList))
 	}
 
-	defer err2.Handle(&err, func() {
+	defer err2.Handle(&err, func(err error) error {
 		glog.Errorln("error:", err)
 		jsonResponse(w, err.Error(), http.StatusInternalServerError)
+		return err
 	})
 
 	glog.V(1).Infoln("BEGIN (new) registration to webAuthn")
@@ -247,14 +249,15 @@ type userInfo struct {
 }
 
 func FinishRegistration(w http.ResponseWriter, r *http.Request) {
-	defer err2.Catch(func(err error) {
+	defer err2.Catch(err2.Err(func(err error) {
 		glog.Warningln("BEGIN finish registration:", err)
-	})
+	}))
 
 	var err error
 
-	defer err2.Handle(&err, func() {
+	defer err2.Handle(&err, func(err error) error {
 		jsonResponse(w, err.Error(), http.StatusBadRequest)
+		return err
 	})
 
 	glog.V(1).Infoln("get session data for registration")
@@ -263,7 +266,7 @@ func FinishRegistration(w http.ResponseWriter, r *http.Request) {
 	user := try.To1(enclave.GetExistingSessionUser(sessionData.UserID))
 	glog.V(1).Infoln("FINISH (new) registration", user.Name)
 
-	defer err2.Handle(&err, func() {
+	defer err2.Handle(&err, func(err error) error {
 		glog.Errorln("error:", err)
 
 		// try to remove added user as registration failed
@@ -272,7 +275,7 @@ func FinishRegistration(w http.ResponseWriter, r *http.Request) {
 			err = fmt.Errorf("finsish reg: %w: %w", err, errRm)
 		}
 		jsonResponse(w, err.Error(), http.StatusInternalServerError)
-		err = nil
+		return nil
 	})
 
 	glog.V(1).Infoln("call web authn finish registration and getting credential")
@@ -295,15 +298,16 @@ type loginUserInfo struct {
 }
 
 func BeginLogin(w http.ResponseWriter, r *http.Request) {
-	defer err2.Catch(func(err error) {
+	defer err2.Catch(err2.Err(func(err error) {
 		glog.Warningln("begin login", err)
-	})
+	}))
 
 	glog.V(1).Infoln("END (new) begin login")
 	var err error
 
-	defer err2.Handle(&err, func() {
+	defer err2.Handle(&err, func(err error) error {
 		jsonResponse(w, err.Error(), http.StatusBadRequest)
+		return err
 	})
 
 	var uInfo loginUserInfo
@@ -322,14 +326,15 @@ func BeginLogin(w http.ResponseWriter, r *http.Request) {
 }
 
 func FinishLogin(w http.ResponseWriter, r *http.Request) {
-	defer err2.Catch(func(err error) {
+	defer err2.Catch(err2.Err(func(err error) {
 		glog.Warningln("finish login error:", err)
-	})
+	}))
 
 	var err error
 
-	defer err2.Handle(&err, func() {
+	defer err2.Handle(&err, func(err error) error {
 		jsonResponse(w, err.Error(), http.StatusBadRequest)
+		return err
 	})
 
 	glog.V(1).Infoln("get session data for finshing login")
@@ -340,14 +345,15 @@ func FinishLogin(w http.ResponseWriter, r *http.Request) {
 	username := user.Name
 	glog.V(1).Infoln("BEGIN (new) finish login:", username)
 
-	defer err2.Handle(&err, func() {
+	defer err2.Handle(&err, func(err error) error {
 		jsonResponse(w, err.Error(), http.StatusInternalServerError)
+		return err
 	})
 
 	// in an actual implementation, we should perform additional checks on
 	// the returned 'credential', i.e. check 'credential.Authenticator.CloneWarning'
 	// and then increment the credentials counter
-	_ = try.To1(webAuthn.FinishLogin(user, sessionData, r))
+	try.To1(webAuthn.FinishLogin(user, sessionData, r))
 
 	jsonResponse(w, &AccessToken{Token: user.JWT()}, http.StatusOK)
 	glog.V(1).Infoln("END (new) finish login", username)
@@ -355,10 +361,10 @@ func FinishLogin(w http.ResponseWriter, r *http.Request) {
 
 // from: https://github.com/go-webauthn/webauthn.io/blob/3f03b482d21476f6b9fb82b2bf1458ff61a61d41/server/response.go#L15
 func jsonResponse(w http.ResponseWriter, d interface{}, c int) {
-	defer err2.Catch(func(err error) {
+	defer err2.Catch(err2.Err(func(err error) {
 		glog.Errorf("json response error: %s", err)
 		http.Error(w, "Error creating JSON response", http.StatusInternalServerError)
-	})
+	}))
 
 	dj := try.To1(json.Marshal(d))
 	w.Header().Set("Content-Type", "application/json")
@@ -368,9 +374,9 @@ func jsonResponse(w http.ResponseWriter, d interface{}, c int) {
 }
 
 func oldBeginRegistration(w http.ResponseWriter, r *http.Request) {
-	defer err2.Catch(func(err error) {
+	defer err2.Catch(err2.Err(func(err error) {
 		glog.Warningln("begin registration error:", err)
-	})
+	}))
 
 	vars := mux.Vars(r)
 	username, ok := vars["username"]
@@ -408,9 +414,10 @@ func oldBeginRegistration(w http.ResponseWriter, r *http.Request) {
 		glog.V(1).Infoln("credexcl:", len(credCreationOpts.CredentialExcludeList))
 	}
 
-	defer err2.Handle(&err, func() {
+	defer err2.Handle(&err, func(err error) error {
 		glog.Errorln("error:", err)
 		jsonResponse(w, err.Error(), http.StatusInternalServerError)
+		return err
 	})
 
 	glog.V(1).Infoln("begin registration to webAuthn")
@@ -428,9 +435,9 @@ func oldBeginRegistration(w http.ResponseWriter, r *http.Request) {
 }
 
 func oldFinishRegistration(w http.ResponseWriter, r *http.Request) {
-	defer err2.Catch(func(err error) {
+	defer err2.Catch(err2.Err(func(err error) {
 		glog.Warningln("BEGIN finish registration:", err)
-	})
+	}))
 
 	var err error
 
@@ -438,11 +445,12 @@ func oldFinishRegistration(w http.ResponseWriter, r *http.Request) {
 	username := vars["username"]
 	glog.V(1).Infoln("finish registration", username)
 
-	defer err2.Handle(&err, func() {
+	defer err2.Handle(&err, func(err error) error {
 		glog.Errorln("error:", err)
 
 		_ = enclave.RemoveUser(username)
 		jsonResponse(w, err.Error(), http.StatusInternalServerError)
+		return err
 	})
 
 	glog.V(1).Infoln("getting existing user", username)
@@ -463,9 +471,9 @@ func oldFinishRegistration(w http.ResponseWriter, r *http.Request) {
 }
 
 func oldBeginLogin(w http.ResponseWriter, r *http.Request) {
-	defer err2.Catch(func(err error) {
+	defer err2.Catch(err2.Err(func(err error) {
 		glog.Warningln("begin login", err)
-	})
+	}))
 
 	var err error
 
@@ -473,8 +481,9 @@ func oldBeginLogin(w http.ResponseWriter, r *http.Request) {
 	username := vars["username"]
 	glog.V(1).Infoln("BEGIN begin login", username)
 
-	defer err2.Handle(&err, func() {
+	defer err2.Handle(&err, func(err error) error {
 		jsonResponse(w, err.Error(), http.StatusInternalServerError)
+		return err
 	})
 
 	user := try.To1(enclave.GetExistingUser(username))
@@ -486,9 +495,9 @@ func oldBeginLogin(w http.ResponseWriter, r *http.Request) {
 }
 
 func oldFinishLogin(w http.ResponseWriter, r *http.Request) {
-	defer err2.Catch(func(err error) {
+	defer err2.Catch(err2.Err(func(err error) {
 		glog.Warningln("finish login error:", err)
-	})
+	}))
 
 	var err error
 
@@ -496,8 +505,9 @@ func oldFinishLogin(w http.ResponseWriter, r *http.Request) {
 	username := vars["username"]
 	glog.V(1).Infoln("BEGIN finish login:", username)
 
-	defer err2.Handle(&err, func() {
+	defer err2.Handle(&err, func(err error) error {
 		jsonResponse(w, err.Error(), http.StatusInternalServerError)
+		return err
 	})
 
 	user := try.To1(enclave.GetExistingUser(username))
@@ -507,7 +517,7 @@ func oldFinishLogin(w http.ResponseWriter, r *http.Request) {
 	// in an actual implementation, we should perform additional checks on
 	// the returned 'credential', i.e. check 'credential.Authenticator.CloneWarning'
 	// and then increment the credentials counter
-	_ = try.To1(webAuthn.FinishLogin(user, sessionData, r))
+	try.To1(webAuthn.FinishLogin(user, sessionData, r))
 
 	jsonResponse(w, &AccessToken{Token: user.JWT()}, http.StatusOK)
 	glog.V(1).Infoln("END finish login", username)

--- a/scripts/mem-dev-run.sh
+++ b/scripts/mem-dev-run.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 GOPATH=${GOPATH:-`go env GOPATH`}
+CERT_PATH=${CERT_PATH:-""}
+
+echo "CERT_PATH: $CERT_PATH"
 
 # MEMORY_ prefix is a memory db, not saved to file
 enclaveFile="MEMORY_enclave.bolt" 
@@ -10,7 +13,7 @@ go run .. \
 	-agency "localhost" \
 	-logging "-logtostderr -v=3" \
 	-origin http://localhost:8090 \
-	-cert-path $GOPATH/src/github.com/findy-network/findy-agent/grpc/cert \
+	-cert-path=$CERT_PATH \
 	-sec-file "$enclaveFile" \
 	-sec-backup-interval 100 \
 	-port 8090

--- a/user/user.go
+++ b/user/user.go
@@ -36,9 +36,10 @@ func InitWithOpts(certPath, addr string, port int, insecure bool, opts []grpc.Di
 		"insecure:", insecure,
 	)
 	if insecure && certPath == "" {
-		glog.Warning("Establishing insecure connection to agency")
+		glog.Warning("Establishing INSECURE connection to agency")
 		baseCfg = client.BuildInsecureClientConnBase(addr, port, opts)
 	} else {
+		glog.Info("Establishing SECURE connection to agency")
 		baseCfg = client.BuildClientConnBase(certPath, addr, port, opts)
 	}
 }

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -67,9 +67,9 @@ func dialer() func(context.Context, string) (net.Conn, error) {
 	insecureServer = s
 
 	go func() {
-		defer err2.Catch(func(err error) {
+		defer err2.Catch(err2.Err(func(err error) {
 			log.Fatal(err)
-		})
+		}))
 		try.To(s.Serve(lis))
 	}()
 


### PR DESCRIPTION
- cert-path flag default must be empty to allow insecure use
- more logging to detect secure/insecure TLS mode
- start script for dev allows no TLS
- err2 automigration and manual fast check
