### PR TITLE
Multiple simultaneous instances of acator & its cmd: Translator service support

### DIFF
--- a/acator/acator_test.go
+++ b/acator/acator_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math/big"
-	"net/url"
 	"strings"
 	"testing"
 
@@ -207,10 +206,9 @@ func TestRegister(t *testing.T) {
 			// var m map[string]any
 			// err := json.NewDecoder(r).Decode(&m)
 			// assert.NoError(err)
-			originURL, _ := url.Parse(tt.args.rpOrigin)
-			Origin = *originURL
+			SetDefInstanceOrigin(tt.args.rpOrigin)
 			r := strings.NewReader(tt.args.registerOptions)
-			js := try.To1(Register(r))
+			js := try.To1(Register(nil, r))
 			assert.INotNil(js)
 
 			ccd, err := protocol.ParseCredentialCreationResponseBody(js)
@@ -257,8 +255,7 @@ func TestRegister_server(t *testing.T) {
 			assert.PushTester(t)
 			defer assert.PopTester()
 
-			originURL, _ := url.Parse(tt.args.rpOrigin)
-			Origin = *originURL
+			SetDefInstanceOrigin(tt.args.rpOrigin)
 			r := strings.NewReader(tt.args.registerOptions)
 			ccd := try.To1(protocol.ParseCredentialCreationResponseBody(r))
 			assert.NotNil(ccd)
@@ -278,8 +275,7 @@ func TestLogin(t *testing.T) {
 
 	assert.PushTester(t)
 	defer assert.PopTester()
-	originURL, _ := url.Parse("http://localhost:8080")
-	Origin = *originURL
+	SetDefInstanceOrigin("http://localhost:8080")
 
 	credID := "baocVG9NhJuTsLeiQBmK5rWggP4Pwz5zEKwzTTlNiRd2Lhi_vb0OmfPMLlcjOwg3S_fHAJhqLXIOOcvMepNhGGkORloK9p3oXmcVk3eV_BsCgZOfO-YpqlTdHis8p9inWL1WhJF2FXvGpEHGtG_wSezFFqf4AllxKth68_f8Kp-1rwnqSJJTS74OjOgZ56DWEAHSCBk"
 	data := try.To1(base64.RawURLEncoding.DecodeString(credID))
@@ -289,7 +285,7 @@ func TestLogin(t *testing.T) {
 
 	credID = newStr
 	credReq := fmt.Sprintf(credentialRequestOptionsFmt, credID)
-	car := try.To1(Login(strings.NewReader(credReq)))
+	car := try.To1(Login(nil, strings.NewReader(credReq)))
 	assert.INotNil(car)
 
 	pcad := try.To1(protocol.ParseCredentialRequestResponseBody(car))

--- a/acator/authn/authncmd.go
+++ b/acator/authn/authncmd.go
@@ -87,7 +87,6 @@ func (ac *Cmd) Validate() (err error) {
 
 func (ac *Cmd) setDefaults() {
 	ac.setPayloads()
-	ac.setInPayloads()
 	ac.setMiddlePayloads()
 
 	if ac.RegisterBegin.Method == "" {
@@ -110,10 +109,10 @@ func (ac *Cmd) setDefaults() {
 		ac.RegisterFinish.Path = "%s/attestation/result"
 	}
 	if ac.LoginBegin.Path == "" {
-		ac.LoginBegin.Path = "%s/assertion/result"
+		ac.LoginBegin.Path = "%s/assertion/options"
 	}
 	if ac.LoginFinish.Path == "" {
-		ac.LoginFinish.Path = "%s/assertion/options"
+		ac.LoginFinish.Path = "%s/assertion/result"
 	}
 }
 
@@ -126,7 +125,8 @@ func (ac *Cmd) setMiddlePayloads() {
 	}
 }
 
-func (ac *Cmd) setInPayloads() {
+// setInPayloads, NOTE: use only for webuathn.io dialect.
+func (ac *Cmd) _() {
 	if ac.RegisterBegin.InPL == "" {
 		ac.RegisterBegin.InPL = `{"username":"%s",
 "response": %s }`
@@ -139,24 +139,10 @@ func (ac *Cmd) setInPayloads() {
 
 func (ac *Cmd) setPayloads() {
 	if ac.RegisterBegin.Payload == "" {
-		ac.RegisterBegin.Payload = `{"username":"%s",
-"algorithms":["es256"],
-"user_verification": "preferred",
-"attestation": "direct",
-"attachment": "cross_platform",
-"discoverable_credential": "preferred"}`
-	}
-	if ac.RegisterFinish.Payload == "" {
-		ac.RegisterFinish.Payload = `{"username":"%s",
-"response": %s}`
+		ac.RegisterBegin.Payload = `{"username":"%s"}`
 	}
 	if ac.LoginBegin.Payload == "" {
-		ac.LoginBegin.Payload = `{"username":"%s",
-"user_verification": "preferred"}`
-	}
-	if ac.LoginFinish.Payload == "" {
-		ac.LoginFinish.Payload = `{"username":"%s",
-"response": %s}`
+		ac.LoginBegin.Payload = `{"username":"%s"}`
 	}
 }
 
@@ -402,7 +388,7 @@ func loginUser(ec *execCmd) (_ *Result, err error) {
 }
 
 func (ec *execCmd) tryHTTPRequest(method, addr string, msg io.Reader) (reader io.ReadCloser) {
-	glog.V(13).Infoln("===", addr)
+	glog.V(13).Infof("=== '%v'", addr)
 	URL := try.To1(url.Parse(addr))
 	request, _ := http.NewRequest(method, URL.String(), msg)
 
@@ -431,7 +417,7 @@ func (ec *execCmd) tryHTTPRequest(method, addr string, msg io.Reader) (reader io
 		err2.Throwf("SERVER error: %v", d)
 	} else if response.StatusCode == http.StatusBadRequest {
 		d := string(try.To1(io.ReadAll(response.Body)))
-		glog.Errorln("BAD:", d)
+		glog.Errorln("BAD Request:", d)
 		err2.Throwf("error bad: %v", d)
 	} else if response.StatusCode != http.StatusOK {
 		err2.Throwf("status code: %v", response.Status)

--- a/main_test.go
+++ b/main_test.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -66,7 +65,7 @@ func TestEndpoints(t *testing.T) {
 			calls: []func(w http.ResponseWriter, r *http.Request){
 				BeginRegistration, FinishRegistration,
 			},
-			buildCalls: []func(jsonStream io.Reader) (io.Reader, error){
+			buildCalls: []func(i *acator.Instance, jsonStream io.Reader) (io.Reader, error){
 				acator.Register,
 			},
 		}
@@ -82,7 +81,7 @@ func TestEndpoints(t *testing.T) {
 			calls: []func(w http.ResponseWriter, r *http.Request){
 				BeginLogin, FinishLogin,
 			},
-			buildCalls: []func(jsonStream io.Reader) (io.Reader, error){
+			buildCalls: []func(i *acator.Instance, jsonStream io.Reader) (io.Reader, error){
 				acator.Login,
 			},
 		}
@@ -100,7 +99,7 @@ func TestEndpoints(t *testing.T) {
 			calls: []func(w http.ResponseWriter, r *http.Request){
 				oldBeginRegistration, oldFinishRegistration,
 			},
-			buildCalls: []func(jsonStream io.Reader) (io.Reader, error){
+			buildCalls: []func(i *acator.Instance, jsonStream io.Reader) (io.Reader, error){
 				acator.Register,
 			},
 		}
@@ -117,7 +116,7 @@ func TestEndpoints(t *testing.T) {
 			calls: []func(w http.ResponseWriter, r *http.Request){
 				oldBeginLogin, oldFinishLogin,
 			},
-			buildCalls: []func(jsonStream io.Reader) (io.Reader, error){
+			buildCalls: []func(i *acator.Instance, jsonStream io.Reader) (io.Reader, error){
 				acator.Login,
 			},
 		}
@@ -131,7 +130,7 @@ type testInfo struct {
 	endpoints  []string
 	envelope   []string
 	calls      []func(w http.ResponseWriter, r *http.Request)
-	buildCalls []func(jsonStream io.Reader) (outStream io.Reader, err error)
+	buildCalls []func(i *acator.Instance, jsonStream io.Reader) (outStream io.Reader, err error)
 }
 
 func doTest(t *testing.T, ti *testInfo) {
@@ -156,7 +155,7 @@ func doTest(t *testing.T, ti *testInfo) {
 		s = fmt.Sprintf(ti.envelope[1], s)
 	}
 
-	repl := try.To1(ti.buildCalls[0](bytes.NewBufferString(s)))
+	repl := try.To1(ti.buildCalls[0](nil, bytes.NewBufferString(s)))
 
 	req2 := httptest.NewRequest(ti.methods[1], ti.endpoints[1], repl)
 	req2.Header = http.Header{"Cookie": res.Header["Set-Cookie"]}
@@ -186,7 +185,7 @@ func setUp() {
 	enclaveKey = ""
 
 	rpOrigin = defaultOrigin
-	acator.Origin = *try.To1(url.Parse(defaultOrigin))
+	acator.SetDefInstanceOrigin(defaultOrigin)
 
 	setupEnv()
 


### PR DESCRIPTION
- preparing with renaming
- acator & acator cmd instantiated for parallel service use
- readablity by using aggregation for http.Client
- defaults for fido-ref architecture endpoints
- correct urls and payloads for fido2 endpoints
