### PR TITLE
gRPC-enclave args & translator full multi-tenancy

### DIFF
--- a/acator/authn/authncmd.go
+++ b/acator/authn/authncmd.go
@@ -430,7 +430,7 @@ func (ec *execCmd) tryHTTPRequest(method, addr string, msg io.Reader) (reader io
 
 func (ec *execCmd) addToCookieJar(URL *url.URL, cookies []*http.Cookie) {
 	for _, c := range cookies {
-		glog.V(1).Infoln("--- adding cookie:", c.String())
+		glog.V(3).Infoln("--- adding cookie:", c.String())
 	}
 	jarCookies := ec.Jar.Cookies(URL)
 	cookies = append(cookies, jarCookies...)
@@ -489,12 +489,12 @@ func (ec *execCmd) checkCookiePath() {
 	} else if ec.CookiePath != "" { // just load page
 		// assert.NotEmpty(cookieFile)
 		// make the http request to load the page AND cookies
-		glog.V(1).Infof("cookie path: '%s'", ec.CookiePath)
+		glog.V(3).Infof("cookie path: '%s'", ec.CookiePath)
 		if ec.CookiePath == "-" {
 			ec.CookiePath = ""
 		}
 		cookiePageURL := ec.URL + ec.CookiePath
-		glog.V(1).Infoln("loading cookie page:", cookiePageURL)
+		glog.V(3).Infoln("loading cookie page:", cookiePageURL)
 		r := ec.tryHTTPRequest("GET", cookiePageURL, &bytes.Buffer{})
 		// we don't know how the server behaves, we don't want it to abort
 		_ = try.To1(io.ReadAll(r))

--- a/acator/authn/authncmd.go
+++ b/acator/authn/authncmd.go
@@ -240,11 +240,13 @@ type execCmd struct {
 
 func newExecCmd(cmd *Cmd) (ec *execCmd) {
 	assert.NotEmpty(cmd.Origin)
+	assert.NotEmpty(cmd.AAGUID)
+
 	ec = new(execCmd)
 	ec.Cmd = *cmd
 	ec.Instance = &acator.Instance{
 		Counter: 0,
-		AAGUID:  uuid.Must(uuid.Parse("12c85a48-4baf-47bd-b51f-f192871a1511")),
+		AAGUID:  uuid.Must(uuid.Parse(cmd.AAGUID)),
 		Origin:  try.To1(url.Parse(cmd.Origin)),
 	}
 	ec.Client = setupClient()

--- a/acator/grpcenclave/client/main.go
+++ b/acator/grpcenclave/client/main.go
@@ -27,6 +27,8 @@ var (
 	cmd        = flag.String("cmd", "login", "FIDO2 cmd: login/register")
 	user       = flag.String("user", "elli", "test user name")
 	serverAddr = flag.String("addr", "localhost", "agency host gRPC address")
+	url        = flag.String("url", "http://localhost:8090", "FIDO2 server URL")
+	origin     = flag.String("origin", "", "FIDO2 server needs origin if not in HTTPS")
 	hexKey     = flag.String("key",
 		"289239187d7c395044976416280b6a283bf65562a06b0bdc3a75a4db4adfe7c7",
 		"soft cipher master key in HEX")
@@ -60,15 +62,16 @@ func main() {
 	conn = try.To1(rpcclient.New(*cert, *serverAddr, *port))
 	defer conn.Close()
 
+	glog.V(3).Infoln("Origin:", *origin)
 	statusCh := try.To1(rpcclient.DoEnter(conn, ctx, &pb.Cmd{
 		Type:          pb.Cmd_Type(pb.Cmd_Type_value[strings.ToUpper(*cmd)]),
 		UserName:      *user,
 		PublicDIDSeed: "",
-		URL:           "http://localhost:8090",
+		URL:           *url,
 		AAGUID:        "12c85a48-4baf-47bd-b51f-f192871a1511",
 		Counter:       0,
 		JWT:           "",
-		Origin:        "",
+		Origin:        *origin,
 	}))
 
 	secEnc := enclave.New(*hexKey)

--- a/acator/grpcenclave/rpcclient/client.go
+++ b/acator/grpcenclave/rpcclient/client.go
@@ -13,6 +13,10 @@ import (
 	"google.golang.org/grpc"
 )
 
+var (
+	c authn.AuthnServiceClient
+)
+
 func New(cert, addr string, port int) (conn *grpc.ClientConn, err error) {
 	defer err2.Handle(&err)
 
@@ -35,7 +39,7 @@ func DoEnter(
 ) {
 	defer err2.Handle(&err)
 
-	c := authn.NewAuthnServiceClient(conn)
+	c = authn.NewAuthnServiceClient(conn)
 	statusCh := make(chan *authn.CmdStatus)
 
 	stream := try.To1(c.Enter(ctx, cmd))
@@ -72,7 +76,9 @@ func DoEnterSecret(
 ) {
 	defer err2.Handle(&err)
 
-	c := authn.NewAuthnServiceClient(conn)
+	// we use the same client
+	//c := authn.NewAuthnServiceClient(conn)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 

--- a/acator/grpcenclave/rpcclient/client.go
+++ b/acator/grpcenclave/rpcclient/client.go
@@ -52,8 +52,9 @@ func DoEnter(
 				close(statusCh)
 				break
 			}
-			glog.V(4).Infoln("--> cmd status:",
+			glog.V(4).Infof("--> cmd ID:%v, status: %v, (secType: %v)",
 				status.GetCmdID(),
+				status.GetType(),
 				status.GetSecType(),
 			)
 			statusCh <- status

--- a/acator/grpcenclave/rpcserver/server.go
+++ b/acator/grpcenclave/rpcserver/server.go
@@ -43,7 +43,7 @@ type authnServer struct {
 	id uint8
 	mu sync.Mutex
 
-	authnCmd [math.MaxUint8+1]*authn.Cmd
+	authnCmd [math.MaxUint8 + 1]*authn.Cmd
 }
 
 func (a *authnServer) AuthFuncOverride(

--- a/acator/grpcenclave/rpcserver/server.go
+++ b/acator/grpcenclave/rpcserver/server.go
@@ -84,6 +84,7 @@ func (a *authnServer) Enter(
 		AAGUID:        cmd.GetAAGUID(),
 		Counter:       cmd.GetCounter(),
 		Token:         cmd.GetJWT(),
+		Origin:        cmd.GetOrigin(),
 	}
 	secEnc := &grpcenclave.Enclave{
 		Cmd:     cmd,

--- a/acator/grpcenclave/server/main.go
+++ b/acator/grpcenclave/server/main.go
@@ -11,8 +11,7 @@ import (
 )
 
 var (
-	// TODO: for Dart we start playing without tls or other security
-	// TODO: we need to build gzip packging to these golang stacks
+	// TODO: bring next line when we need to test with certs the server.
 	//cert = flag.String("cert", "../../../scripts/test-cert/", "TLS cert path")
 	port = flag.Int("port", 50053, "agency host gRPC port")
 )


### PR DESCRIPTION
- **update todos**
- **add -url flag**
- **add missing origin**
- **add FIDO2 server's `url` and `origin` usage and flags**
- **multi-tenant grpcenclave**
- **better status log line in reading loop**
- **standard map -> x.RWMap for thread safety**
- **change cookie related logging lvl 1 -> 3**
- **bug fix: uses AAGUUID**
- **use context for Done, new asserts, continuing with mutex..**
- **works, but pessimistic**
- **use mutual client var for both gRPC call**
- **free method added, works without error**
- **final cycle-buf implementation**
- **gofmt**
- **minor refactorings**
